### PR TITLE
Added "checkmark", "devkit", "haptics", "ionicons", and "offscreencan…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,12 +5,17 @@
   ],
   "cSpell.words": [
     "Blendshapes",
+    "checkmark",
+    "devkit",
     "Fileset",
     "fontawesome",
     "fortawesome",
+    "haptics",
     "homescreen",
+    "ionicons",
     "Landmarker",
     "mediapipe",
+    "offscreencanvas",
     "POPIA"
   ],
   "java.configuration.updateBuildConfiguration": "automatic"


### PR DESCRIPTION
…vas" to the list of cSpell words in settings.json.